### PR TITLE
Splitted uart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vscode
 *.bin
 *.hex
+*.txt

--- a/firmware/memory.x
+++ b/firmware/memory.x
@@ -8,5 +8,5 @@ MEMORY
   /* Need to add header size here to origin (0x800) to make SD boot correctly */
   /* NOTE if you want to use unsigned firmware use flash ORIGIN 0x19000       */
   FLASH (rx) : ORIGIN = 0x19000, LENGTH = 52K
-  RAM : ORIGIN = 0x20000000 + 10760, LENGTH = 24K - 10760
+  RAM : ORIGIN = 0x20000000 + 9968, LENGTH = 24K - 9968
 }

--- a/firmware/src/comms.rs
+++ b/firmware/src/comms.rs
@@ -1,11 +1,9 @@
-use crate::consts::{ATT_MTU, BT_MAX_NUM_PKT, MTU};
+use crate::consts::{BT_MAX_NUM_PKT, MTU};
 use crate::{BT_DATA_RX, BT_STATE, RSSI_TX, RSSI_VALUE};
 use crate::{IRQ_OUT_PIN, TX_BT_VEC};
 use defmt::info;
 use embassy_nrf::buffered_uarte::{BufferedUarteRx, BufferedUarteTx};
-use embassy_nrf::{
-    peripherals::{TIMER1, UARTE0},
-};
+use embassy_nrf::peripherals::{TIMER1, UARTE0};
 use embedded_io_async::Write;
 use heapless::Vec;
 use host_protocol::{Bluetooth, HostProtocolMessage, COBS_MAX_MSG_SIZE};

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -50,7 +50,7 @@ bind_interrupts!(struct Irqs {
 
 // Signal for BT state
 static BT_STATE: Signal<ThreadModeRawMutex, bool> = Signal::new();
-static TX_BT_VEC: Mutex<ThreadModeRawMutex, Vec<Vec<u8, ATT_MTU>, 8>> = Mutex::new(Vec::new());
+static TX_BT_VEC: Mutex<ThreadModeRawMutex, Vec<Vec<u8, ATT_MTU>, 4>> = Mutex::new(Vec::new());
 static RSSI_VALUE: Mutex<ThreadModeRawMutex, u8> = Mutex::new(0);
 static BT_DATA_RX: Channel<ThreadModeRawMutex, Vec<u8, ATT_MTU>, 4> = Channel::new();
 static RSSI_TX: Channel<ThreadModeRawMutex,u8,1> = Channel::new();

--- a/firmware/src/nus.rs
+++ b/firmware/src/nus.rs
@@ -32,7 +32,6 @@ impl Nus {
             NusEvent::RxWrite(data) => {
                 info!("Received: {} bytes {:?}", data.len(), data);
                 let _ = BT_DATA_RX.try_send(data);
-                info!("Buffer len {}", BT_DATA_RX.len())
             }
         }
     }

--- a/firmware/src/server.rs
+++ b/firmware/src/server.rs
@@ -56,7 +56,7 @@ pub fn initialize_sd() -> &'static mut Softdevice {
             _bitfield_1: raw::ble_gap_cfg_device_name_t::new_bitfield_1(raw::BLE_GATTS_VLOC_STACK as u8),
         }),
         conn_gatts: Some(raw::ble_gatts_conn_cfg_t{
-            hvn_tx_queue_size : 6,
+            hvn_tx_queue_size : 3,
         }),
         
         ..Default::default()
@@ -93,7 +93,7 @@ async fn notify_data_tx<'a>(server: &'a Server, connection: &'a Connection) {
         }
 
         // Sleep for one millisecond.
-        Timer::after(Duration::from_millis(1)).await
+        Timer::after(Duration::from_micros(500)).await
     }
 }
 


### PR DESCRIPTION
Added some improvements:

- Uart channels are splitted ( rx and tx ) this permits to avoid using a mutex locking peripheral.
- Added a tweak on NUS ( nrf bt serial ) to have more events buffered, this increase RAM usage of SD.
