### PR TITLE
Remove and ignore `cosign2.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.bin
 *.hex
 *.txt
+cosign2.toml

--- a/cosign2.toml
+++ b/cosign2.toml
@@ -1,3 +1,0 @@
-pubkey = "03b72bada7b2a06f931b60b1bfdd6f935870c77e254fe8b241c008b9472ad73055"
-secret = "/home/pinballwizard/rust_prj/Foundation/prime-ble-firmware/cosign2-priv.pem" # NOTE: the path must be absolute
-target = "atsama5d27-keyos"


### PR DESCRIPTION
This config isn't really meant to be shared in version control. Everyone who's going to build and sign the firmware must have their own `cosign2.toml` with their own keys in it.

Note for `xtask`: check existence of the `cosign2.toml` and suggest the user to add/create it before attempting to sign with `cosign2` to avoid giving an unhelpful error.