### PR TITLE
use system srecord by default (if available)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.71",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1954,6 +1954,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cad3279ade7346b96e38731a641d7343dd6a53d55083dd54eadfa5a1b38c6b"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
@@ -2059,4 +2077,5 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+ "which 7.0.0",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.41"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+which = "7.0.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -43,6 +43,10 @@ fn project_root() -> PathBuf {
     Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()
 }
 
+fn srecord() -> PathBuf {
+    which::which("srec_cat").unwrap_or(project_root().join(SRECORD_PATH).join("srec_cat"))
+}
+
 pub fn cargo() -> String {
     env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
 }
@@ -349,17 +353,8 @@ fn sign_bt_firmware() {
 }
 
 fn build_bt_package() {
-    #[cfg(target_os = "linux")]
-    let srecord: PathBuf = project_root().join(SRECORD_PATH).join("srec_cat");
-
-    #[cfg(target_os = "windows")]
-    let srecord: PathBuf = project_root().join(SRECORD_PATH).join("srec_cat");
-
-    #[cfg(target_os = "macos")]
-    let srecord: PathBuf = project_root().join(SRECORD_PATH).join("srec_cat");
-
     tracing::info!("Converting bin signed package to hex file with starting offset 0x19800");
-    let status = Command::new(srecord.clone())
+    let status = Command::new(srecord().clone())
         .current_dir(project_root().join(SRECORD_PATH))
         .args([
             "../../BtPackage/BT_application_signed.bin",
@@ -374,7 +369,7 @@ fn build_bt_package() {
         panic!("Converting bin to hex failed");
     }
 
-    let status = Command::new(srecord.clone())
+    let status = Command::new(srecord().clone())
         .current_dir(project_root().join(SRECORD_PATH))
         .args([
             "../../BtPackage/BT_application_signed.hex",
@@ -392,7 +387,7 @@ fn build_bt_package() {
     }
 
     tracing::info!("Merging softdevice bootloader and BT signed application in single hex");
-    let status = Command::new(srecord.clone())
+    let status = Command::new(srecord().clone())
         .current_dir(project_root().join(SRECORD_PATH))
         .args([
             "../../BtPackage/BT_application_signed.hex",
@@ -426,17 +421,8 @@ fn build_bt_package() {
 }
 
 fn build_bt_package_debug() {
-    #[cfg(target_os = "linux")]
-    let srecord: PathBuf = project_root().join(SRECORD_PATH).join("srec_cat");
-
-    #[cfg(target_os = "windows")]
-    let srecord: PathBuf = project_root().join(SRECORD_PATH).join("srec_cat");
-
-    #[cfg(target_os = "macos")]
-    let srecord: PathBuf = project_root().join(SRECORD_PATH).join("srec_cat");
-
     tracing::info!("Merging softdevice bootloader and BT signed application in single hex");
-    let status = Command::new(srecord.clone())
+    let status = Command::new(srecord().clone())
         .current_dir(project_root().join(SRECORD_PATH))
         .args([
             "../../BtPackageDebug/BtappDebug.hex",


### PR DESCRIPTION
I am on Linux and the procured srecord elf file can't find the associated shared lib (because of NixOS), so I have to use the system provided one.

Is this PR still works on Windows/Mac ?