### PR TITLE
Added an uart full error message

### DIFF
--- a/firmware/src/comms.rs
+++ b/firmware/src/comms.rs
@@ -248,6 +248,9 @@ async fn bluetooth_handler(msg: Bluetooth<'_>) -> Option<HostProtocolMessage<'_>
                 let mut buffer_tx_bt = BT_DATA_TX.lock().await;
                 if buffer_tx_bt.len() < BT_MAX_NUM_PKT {
                     let _ = buffer_tx_bt.push(Vec::from_slice(data).unwrap());
+                } else {
+                    let msg = HostProtocolMessage::Bluetooth(Bluetooth::UartBufferFull);
+                    return Some(msg);
                 }
             }
         }
@@ -260,6 +263,7 @@ async fn bluetooth_handler(msg: Bluetooth<'_>) -> Option<HostProtocolMessage<'_>
         Bluetooth::ReceivedData(_) => {}
         Bluetooth::AckFirmwareVersion { .. } => {}
         Bluetooth::AckBtAaddress { .. } => {}
+        Bluetooth::UartBufferFull => {}
     }
     None
 }


### PR DESCRIPTION
Hi @eupn , @georgesFoundation ,

just a small commit with a error in case of full buffer of messages from MPU uart to ble ( ble stack maybe not be able to send immediately all messages due to FULL_RESOURCE error of the stack ).

Could be an idea to have a signal for MPU to get a semaphore to wait for a small amount of time to send other messages? This is useful imo only in the case that MPU could send "big" data to ble, in case we send a max of 1KBytes ( just to say a number ) this could be useless.

Take a look!